### PR TITLE
Drop unneeded tsconfig rootDirs setting

### DIFF
--- a/{{cookiecutter.project_slug}}/tsconfig.alfred.json
+++ b/{{cookiecutter.project_slug}}/tsconfig.alfred.json
@@ -1,7 +1,6 @@
 {
   "extends": "./tsconfig.json",
   "compilerOptions": {
-    "rootDirs": ["src/common", "src/alfred"],
     "outDir": "./dist/alfred/"
   },
   "include": [


### PR DESCRIPTION
This was an artifact of an abandoned development technique