### PR TITLE
Add ability to log user-visible-status

### DIFF
--- a/{{cookiecutter.project_slug}}/info.plist
+++ b/{{cookiecutter.project_slug}}/info.plist
@@ -98,7 +98,7 @@ set -eu
 				<key>queuemode</key>
 				<integer>2</integer>
 				<key>runningsubtext</key>
-				<string></string>
+				<string>Running {{cookiecutter.project_name}}...</string>
 				<key>script</key>
 				<string>query=$1
 
@@ -111,7 +111,7 @@ set -eu
 				<key>scriptfile</key>
 				<string></string>
 				<key>subtext</key>
-				<string></string>
+				<string>Enter text for {{cookiecutter.project_name}}</string>
 				<key>title</key>
 				<string>{{ cookiecutter.project_name }}</string>
 				<key>type</key>

--- a/{{cookiecutter.project_slug}}/src/alfred/alfred-logger.ts
+++ b/{{cookiecutter.project_slug}}/src/alfred/alfred-logger.ts
@@ -13,6 +13,8 @@ export default class AlfredLogger {
   log = (message?: any, ...optionalParams: any[]) => { };
 
   debug = (s: string): void => { };
+
+  userVisibleStatus = (s: string): void => { };
   /* eslint-enable @typescript-eslint/no-explicit-any */
   /* eslint-enable @typescript-eslint/no-unused-vars */
   /* eslint-enable @typescript-eslint/no-empty-function */

--- a/{{cookiecutter.project_slug}}/src/asana-typeahead.ts
+++ b/{{cookiecutter.project_slug}}/src/asana-typeahead.ts
@@ -21,9 +21,7 @@ export const pullResult = async (text: string) => {
 
   logger.log('requesting typeahead with workspaceGid', workspaceGid,
     ' and query of ', query);
-  chrome.omnibox.setDefaultSuggestion({
-    description: `<dim>Searching for ${text}...</dim>`,
-  });
+  logger.userVisibleStatus(`Searching for ${text}...`);
 
   // https://developers.asana.com/docs/typeahead
   const client = await fetchClient();

--- a/{{cookiecutter.project_slug}}/src/chrome-extension/chrome-extension-logger.ts
+++ b/{{cookiecutter.project_slug}}/src/chrome-extension/chrome-extension-logger.ts
@@ -2,4 +2,10 @@ export default class ChromeExtensionLogger {
   log = console.log;
 
   debug = console.debug;
+
+  userVisibleStatus = (message: string): void => {
+    chrome.omnibox.setDefaultSuggestion({
+      description: `<dim>${message}</dim>`,
+    });
+  };
 }

--- a/{{cookiecutter.project_slug}}/src/logger.ts
+++ b/{{cookiecutter.project_slug}}/src/logger.ts
@@ -4,6 +4,8 @@ export default abstract class Logger {
   abstract log(message?: any, ...optionalParams: any[]): void;
 
   abstract debug(message?: any, ...optionalParams: any[]): void;
+
+  abstract userVisibleStatus(message: string): void;
   /* eslint-enable @typescript-eslint/no-explicit-any */
   /* eslint-enable @typescript-eslint/no-unused-vars */
 }


### PR DESCRIPTION
This abstracts out the flash show in the omnibox during an Asana task search today.  Currently there's no dynamic Alfred equivalent, just a static one.