### PR TITLE
Update git remote name to cookiecutter-upstream

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -62,9 +62,9 @@ replay: watch
 update_from_cookiecutter: ## Bring in changes from template project used to create this repo
 	bundle exec overcommit --uninstall
 	git checkout main && git pull && git checkout -b update-from-upstream-cookiecutter-$$(date +%Y-%m-%d-%H%M)
-	git fetch upstream
+	git fetch cookiecutter-upstream
 	git fetch -a
-	git merge upstream/main --allow-unrelated-histories || true
+	git merge cookiecutter-upstream/main --allow-unrelated-histories || true
 	bundle exec overcommit --install
 	@echo
 	@echo "Please resolve any merge conflicts below and push up a PR with:"


### PR DESCRIPTION
Hopefully this one won't confuse forge