### PR TITLE
Add steps for directly publishing .alfredworkflow file

### DIFF
--- a/{{cookiecutter.project_slug}}/.gitignore
+++ b/{{cookiecutter.project_slug}}/.gitignore
@@ -61,3 +61,4 @@ requirements_dev.txt.installed
 # From release process
 /package.zip
 /alfred-{{cookiecutter.project_slug}}-*.tgz
+/{{cookiecutter.project_name}}.alfredworkflow

--- a/{{cookiecutter.project_slug}}/DEVELOPMENT.md
+++ b/{{cookiecutter.project_slug}}/DEVELOPMENT.md
@@ -52,7 +52,7 @@ development.  See the `.envrc` file for detail.
    ```
 {%- endif %}
 
-## Initial release of Alfred package to npm
+## Initial release of Alfred package
 
 Walk through these steps:
 
@@ -63,6 +63,17 @@ git stash
 npm publish
 alfy-cleanup
 npm install -g alfred-{{cookiecutter.project_slug}} --upgrade
+```
+
+Then, load Alfred | Preferences | Workflows |
+{{cookiecutter.project_name}} | right click | Export ... | Export | choose this
+directory | Export
+
+Once done, make a GitHub release with the exported file:
+
+```
+new_release=$(npm version --json | jq -r '."alfred-{{cookiecutter.project_slug}}"')
+gh release create v${new_release:?} '{{cookiecutter.project_name}}.alfredworkflow'
 ```
 
 Drop the following markdown into README.md in the 'Installing Alfred workflow' section.
@@ -80,7 +91,7 @@ Once down, configure: Alfred | Workflows |
 
 Remove this section.
 
-## Releasing Alfred package to npm
+## Releasing Alfred package
 
 Related backlog tasks:
 
@@ -152,7 +163,7 @@ Download file.  Install.
 1. PR related changes in here
 1. Submit for review
 1. Wait for approval
-1. Update README.md with CWS icon linking to listing after the first paragraph - example: `[![Available in the Chrome Web Store](https://storage.googleapis.com/web-dev-uploads/image/WlD8wC6g8khYWPJUsQceQkhXSlv1/tbyBjqi7Zu733AAKA5n4.png)](WEBSTORE LINK HERE)`
+1. Update README.md with CWS icon linking to listing after the first paragraph - example: p`[![Available in the Chrome Web Store](https://storage.googleapis.com/web-dev-uploads/image/WlD8wC6g8khYWPJUsQceQkhXSlv1/tbyBjqi7Zu733AAKA5n4.png)](WEBSTORE LINK HERE)`
 1. Replace 'Installing Chrome Extension' in README.md with the CWS icon.
 1. Update README.md with screenshots - example: `<img src="./docs/screenshot-1.png" alt="screenshot showing Asana task description and repeating above keystrokes" height="400"/>`
 1. Drop this section

--- a/{{cookiecutter.project_slug}}/DEVELOPMENT.md
+++ b/{{cookiecutter.project_slug}}/DEVELOPMENT.md
@@ -68,9 +68,14 @@ npm install -g alfred-{{cookiecutter.project_slug}} --upgrade
 Drop the following markdown into README.md in the 'Installing Alfred workflow' section.
 
 ```markdown
-1. `npm install -g alfred-{{ cookiecutter.project_slug }}`
-2. Alfred | Workflows | File Asana task | Configure workflow and
-   variables icon | configure workspace name and access key.
+Either download and double click the latest release's [.alfredworkflow
+file](https://github.com/{{cookiecutter.github_username}}/{{cookiecutter.project_slug}}/releases)
+or install via npm with `npm install -g
+alfred-{{cookiecutter.project_slug}}`
+
+Once down, configure: Alfred | Workflows |
+{{cookiecutter.project_name}} | Configure workflow and variables icon
+| configure workspace name and access key.
 ```
 
 Remove this section.
@@ -80,6 +85,8 @@ Remove this section.
 Related backlog tasks:
 
 * Do npm Alfred release of cookiecutter-multicli projects in CircleCI (after other tests pass)
+
+First, run these commands:
 
 ```sh
 git checkout main
@@ -95,6 +102,19 @@ npm publish
 alfy-cleanup
 npm install -g alfred-{{cookiecutter.project_slug}} --upgrade
 ```
+
+Then, load Alfred | Preferences | Workflows |
+{{cookiecutter.project_name}} | right click | Export ... | Export | choose this
+directory | Export
+
+Once done, make a GitHub release with the exported file:
+
+```
+new_release=$(npm version --json | jq -r '."alfred-{{cookiecutter.project_slug}}"')
+gh release create v${new_release:?} '{{cookiecutter.project_name}}.alfredworkflow'
+```
+
+Download file.  Install.
 
 ## Initial release to Chrome Web Store
 


### PR DESCRIPTION
This addresses concerns with npm-mediated install process:

https://www.alfredforum.com/topic/17503-alfred-squoosh/#comment-90272